### PR TITLE
fix: increase active hint border radius

### DIFF
--- a/schemas/org.gnome.shell.extensions.gnome-mosaic.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.gnome-mosaic.gschema.xml
@@ -8,7 +8,7 @@
         </key>
 
         <key type="u" name="active-hint-border-radius">
-            <default>15</default>
+            <default>19</default>
             <range min="0" max="30"/>
             <summary>Border radius for active window hint, in pixels</summary>
         </key>


### PR DESCRIPTION
increase the active hint border radius default to 19

relates #8 