### PR TITLE
fix(cache):[#134] set fork length_left on restore

### DIFF
--- a/src/fork.ts
+++ b/src/fork.ts
@@ -98,6 +98,7 @@ export class Fork {
                 : Lib.Orientation.HORIZONTAL
         );
         fork.on_primary_display = data.on_primary_display;
+        fork.length_left = data.length_left;
         fork.prev_length_left = data.prev_length_left;
         fork.prev_ratio = data.prev_ratio;
         fork.orientation_changed = data.orientation_changed;


### PR DESCRIPTION
sets the fork length_left on rehydration as that was left out

closes #134 