### PR TITLE
feat: optimize window borders

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1014,8 +1014,8 @@ export class Ext extends Ecs.System<ExtEvent> {
                     if (prev.is_maximized()) {
                         prev.meta.set_unmaximize_flags
                             ? prev.meta.set_unmaximize_flags(
-                                Meta.MaximizeFlags.BOTH
-                            )
+                                  Meta.MaximizeFlags.BOTH
+                              )
                             : prev.meta.unmaximize(Meta.MaximizeFlags.BOTH);
                     }
                 }
@@ -1054,12 +1054,16 @@ export class Ext extends Ecs.System<ExtEvent> {
                 this.border_timeout = null;
             }
 
-            this.border_timeout = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 250, () => {
-                this.is_switching_workspace = false;
-                this.show_border_on_focused();
-                this.border_timeout = null;
-                return GLib.SOURCE_REMOVE;
-            });
+            this.border_timeout = GLib.timeout_add(
+                GLib.PRIORITY_DEFAULT,
+                250,
+                () => {
+                    this.is_switching_workspace = false;
+                    this.show_border_on_focused();
+                    this.border_timeout = null;
+                    return GLib.SOURCE_REMOVE;
+                }
+            );
             return;
         }
 
@@ -1742,14 +1746,14 @@ export class Ext extends Ecs.System<ExtEvent> {
                                 ? swap
                                     ? [area.x, area.y, half_width, area.height]
                                     : [
-                                        area.x + half_width,
-                                        area.y,
-                                        half_width,
-                                        area.height,
-                                    ]
+                                          area.x + half_width,
+                                          area.y,
+                                          half_width,
+                                          area.height,
+                                      ]
                                 : swap
-                                    ? [area.x, area.y, area.width, half_height]
-                                    : [
+                                  ? [area.x, area.y, area.width, half_height]
+                                  : [
                                         area.x,
                                         area.y + half_height,
                                         area.width,
@@ -2131,7 +2135,7 @@ export class Ext extends Ecs.System<ExtEvent> {
         if (this.overlay) {
             this.overlay.set_style(
                 `border-radius: ${radii_values};` +
-                `background-color: ${major > 46 ? '-st-accent-color' : this.settings.gnome_legacy_accent_color()};`
+                    `background-color: ${major > 46 ? '-st-accent-color' : this.settings.gnome_legacy_accent_color()};`
             );
         }
     }
@@ -2315,7 +2319,7 @@ export class Ext extends Ecs.System<ExtEvent> {
                             if (
                                 this.auto_tiler &&
                                 meta_window.window_type ===
-                                Meta.WindowType.DESKTOP
+                                    Meta.WindowType.DESKTOP
                             ) {
                                 refocus_tiled_window();
                             } else {
@@ -2372,11 +2376,15 @@ export class Ext extends Ecs.System<ExtEvent> {
                 this.border_timeout = null;
             }
 
-            this.border_timeout = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 1000, () => {
-                this.is_switching_workspace = false;
-                this.border_timeout = null;
-                return GLib.SOURCE_REMOVE;
-            });
+            this.border_timeout = GLib.timeout_add(
+                GLib.PRIORITY_DEFAULT,
+                1000,
+                () => {
+                    this.is_switching_workspace = false;
+                    this.border_timeout = null;
+                    return GLib.SOURCE_REMOVE;
+                }
+            );
         });
 
         this.connect(workspace_manager, 'active-workspace-changed', () => {


### PR DESCRIPTION
## 📝 Description

This PR optimizes window border rendering performance and fixes visual glitches during workspace transitions and small border widths.

**Changes:**
- Implemented border rect caching to skip redundant updates
- Added event-driven Z-ordering via `restacked` signal
- Deferred non-critical style updates using `GLib.idle_add`
- Added workspace transition detection to prevent border flicker
- Fixed border gap issue with small border widths (2-3px)

Fixes #164  
Fixes #163  
Fixes #62

---

## 🔍 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code cleanup or refactor
- [ ] 🧪 Tests
- [ ] 📝 Documentation update
- [ ] ⚙️ CI/CD or build system update

---

## ✅ How Has This Been Tested?

**Manual Testing:**
- [x] Tested border rendering on focused windows
- [x] Verified workspace switching behavior
- [x] Checked border visibility during window tiling
- [x] Confirmed no visual glitches or delays
- [x] Validated Z-ordering (borders behind content/menus)
- [x] Tested with small border widths (2-3px) - gap resolved

**Test Configuration:**

- OS: Fedora Linux
- GNOME Shell: 49

---

## 📸 Screenshots (if applicable)

Testing border radius and workspace change:

https://github.com/user-attachments/assets/e824cfa9-34cb-4d8e-8988-f9ceb8dd3361

Testing border width:

[Gravação de tela de 2025-11-22 02-48-49.webm](https://github.com/user-attachments/assets/0b9961f9-e769-463b-ab84-2755d44fa49f)

---

## 📋 Checklist

- [x] Code follows the project's style guidelines
- [x] I have self-reviewed my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to documentation (if needed)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

---

## 🧠 Additional Context

**Performance Improvements:**
- Reduced CPU usage during idle by caching border rectangles
- Eliminated redundant restack operations by using event-driven approach
- Improved responsiveness by deferring non-critical style updates

**Bug Fixes:**
- Border gap with small widths (2-3px) resolved by triggering layout recalculation when border width changes
- Border flicker during workspace transitions eliminated with 250ms delay

**Implementation Notes:**
- Border rect caching compares previous dimensions before applying updates
- `restacked` signal automatically handles Z-order corrections
- Workspace transition delay prevents border "pop-in" effect during animations
- Dynamic border width tracking ensures proper size recalculation

**Trade-offs:**
- Added minimal memory overhead for caching border rect (4 integers per window)
- 250ms delay on workspace switch is imperceptible but ensures smooth transitions