### PR TITLE
fix(cache): handle rehydration failure

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3150,12 +3150,12 @@ export default class MosaicExtension extends Extension {
                 }
             }
 
+            settings.set_string(MOSAIC_CACHED_STATE, '');
+
             if (!ext) {
                 log.error('EXT IS NULL - CONFIGURATION SKIPPED');
                 return false;
             }
-
-            settings.set_string(MOSAIC_CACHED_STATE, '');
 
             log.debug('CONFIGURING EXTENSION');
             if (ext.settings.show_skiptaskbar()) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3240,8 +3240,6 @@ export default class MosaicExtension extends Extension {
 
         enable_window_attention_handler();
     }
-
-    // delete_cache = () => ext!.settings.ext.set_string(MOSAIC_CACHED_STATE, '');
 }
 
 const handler = windowAttentionHandler;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -384,12 +384,8 @@ export class Ext extends Ecs.System<ExtEvent> {
             log.debug('CACHE SUCCESSFULLY RESTORED');
             return ext;
         } catch (error) {
-            if (error instanceof Error) {
-                log.debug(error.message);
-            }
-            log.debug('CACHE UNSUCCESSFULLY RESTORED');
+            throw error;
         }
-        return null;
     }
 
     // System interface
@@ -3137,9 +3133,12 @@ export default class MosaicExtension extends Extension {
                     );
                     ext = Ext.fromJSON(data);
                     restored = true;
-                } catch {
+                } catch (error) {
                     ext = null;
                     log.debug('COULD NOT READ CACHED STATE');
+                    if (error instanceof Error) {
+                        log.debug(error.message);
+                    }
                 }
 
                 if (!restored) {


### PR DESCRIPTION
## 📝 Description
In the enable rehydration process, throw error up to enable func so that the catch functionality inside the enable function runs.  This allows the proper fallback extension creation behavior if the rehydration fails.

---

## 🔍 Type of Change

Please delete options that are not relevant.

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code cleanup or refactor
- [ ] 🧪 Tests
- [ ] 📝 Documentation update
- [ ] ⚙️ CI/CD or build system update
