### PR TITLE
fix:[#189] remove idicator button ref in sessionMode updated

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2229,7 +2229,7 @@ export class Ext extends Ecs.System<ExtEvent> {
 
         this.connect(sessionMode, 'updated', () => {
             if (indicator) {
-                indicator.button.visible = !sessionMode.isLocked;
+                indicator.visible = !sessionMode.isLocked;
             }
 
             if (sessionMode.isLocked) {


### PR DESCRIPTION
set the indicator visibility instead of referencing the button. this was a leftover from #167 

closes #189 