### PR TITLE
fix(window):[#194] catch decorate async error

### DIFF
--- a/src/window.ts
+++ b/src/window.ts
@@ -219,7 +219,9 @@ export class ShellWindow {
     }
 
     private async decorate(ext: Ext) {
-        if (await this.may_decorate()) {
+        var may_decorate = false;
+        may_decorate = await this.may_decorate().catch(() => false);
+        if (may_decorate) {
             if (!this.is_client_decorated()) {
                 if (ext.settings.show_title()) {
                     this.decoration_show(ext);
@@ -234,7 +236,9 @@ export class ShellWindow {
         _ext: Ext,
         callback: (xid: string) => void
     ): Promise<void> {
-        if (await this.may_decorate()) {
+        var may_decorate = false;
+        may_decorate = await this.may_decorate().catch(() => false);
+        if (may_decorate) {
             const xid = this.xid();
             if (xid) callback(xid);
         }


### PR DESCRIPTION
## 📝 Description
catch the decorate await function and set to false on error.  this silences the error noise in journalctl

---

## 🔍 Type of Change

Please delete options that are not relevant.

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code cleanup or refactor
- [ ] 🧪 Tests
- [ ] 📝 Documentation update
- [ ] ⚙️ CI/CD or build system update

closes #194 
