### PR TITLE
fix: fullscreen window rehydration

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -484,21 +484,11 @@ export class Ext extends Ecs.System<ExtEvent> {
 
                     case WindowEvent.Fullscreen:
                         if (this.auto_tiler) {
-                            let attachment = this.auto_tiler.attached.get(
+                            const attachment = this.auto_tiler.attached.get(
                                 win.entity
                             );
-                            if (attachment) {
-                                if (!win.meta.is_fullscreen()) {
-                                    let fork = this.auto_tiler.forest.forks.get(
-                                        win.entity
-                                    );
-                                    if (fork) {
-                                        this.auto_tiler.reflow(
-                                            this,
-                                            win.entity
-                                        );
-                                    }
-                                }
+                            if (attachment && !win.meta.is_fullscreen()) {
+                                this.auto_tiler.reflow(this, win.entity);
                             }
                         }
 

--- a/src/window.ts
+++ b/src/window.ts
@@ -388,6 +388,10 @@ export class ShellWindow {
     }
 
     move(ext: Ext, rect: Rectangular, on_complete?: () => void) {
+        if (this.meta.is_fullscreen()) {
+            return;
+        }
+
         if (!this.same_workspace() && this.is_maximized()) {
             return;
         }

--- a/src/window.ts
+++ b/src/window.ts
@@ -80,7 +80,8 @@ export class ShellWindow {
         entity: Entity,
         window: Meta.Window,
         window_app: any,
-        ext: Ext
+        ext: Ext,
+        skip_tags: boolean = false
     ) {
         this.window_app = window_app;
 
@@ -90,7 +91,7 @@ export class ShellWindow {
         this.known_workspace = this.workspace_id();
 
         // Float fullscreen windows by default, such as Kodi.
-        if (this.meta.is_fullscreen()) {
+        if (!skip_tags && this.meta.is_fullscreen()) {
             ext.add_tag(entity, Tags.Floating);
         }
 
@@ -132,7 +133,8 @@ export class ShellWindow {
             data.entity,
             data.meta,
             Shell.WindowTracker.get_default().get_window_app(data.meta),
-            ext
+            ext,
+            true
         );
         win.known_workspace = data.workspace;
         win.grab = data.grab;


### PR DESCRIPTION
## 📝 Description

- reflow autotiler on fullscreen event
- skip adding tags on rehydration if window is fullscreen
- add guard to move func if fullscreen

---

## 🔍 Type of Change

Please delete options that are not relevant.

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code cleanup or refactor
- [ ] 🧪 Tests
- [ ] 📝 Documentation update
- [ ] ⚙️ CI/CD or build system update

---
