### PR TITLE
fix: cache display info on lock

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -4,10 +4,7 @@ import type {Ext} from './extension.js';
 
 /** Type representing all possible events handled by the extension's system. */
 export type ExtEvent =
-    | GenericCallback
-    | ManagedWindow
-    | CreateWindow
-    | GlobalEventTag;
+    GenericCallback | ManagedWindow | CreateWindow | GlobalEventTag;
 
 /** Eevnt with generic callback */
 export interface GenericCallback {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -309,6 +309,10 @@ export class Ext extends Ecs.System<ExtEvent> {
             storages: this.storages,
             tags: this.tags_,
             free_slots: this.free_slots,
+            displays: [
+                this.displays[0],
+                Array.from(this.displays[1].entries()),
+            ],
         };
         return data;
     }
@@ -381,6 +385,17 @@ export class Ext extends Ecs.System<ExtEvent> {
                 (obj: any) => new Set(Object.entries(obj))
             );
             ext.free_slots = data.free_slots;
+            if (data.displays) {
+                const [primary, entries] = data.displays;
+                const restored = new Map<number, Display>();
+                for (const [index, {area, ws}] of entries) {
+                    restored.set(index, {
+                        area: Rectangle.fromJSON(area),
+                        ws: Rectangle.fromJSON(ws),
+                    });
+                }
+                ext.displays = [primary, restored];
+            }
             log.debug('CACHE SUCCESSFULLY RESTORED');
             return ext;
         } catch (error) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2880,8 +2880,8 @@ export class Ext extends Ecs.System<ExtEvent> {
                             toplevels.push(f);
 
                             let migration:
-                                | null
-                                | [Fork, number, Rectangle, boolean] = null;
+                                null | [Fork, number, Rectangle, boolean] =
+                                null;
 
                             const displays = this.displays[1];
 


### PR DESCRIPTION
## 📝 Description

the display data structure is not being stored in the cache which causes the forks to resize on unlock.  this change stringifies the display config and rehydrates on unlock

---

## 🔍 Type of Change

Please delete options that are not relevant.

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code cleanup or refactor
- [ ] 🧪 Tests
- [ ] 📝 Documentation update
- [ ] ⚙️ CI/CD or build system update

closes #156 
relates #145 