### PR TITLE
fix(cache):[#151] store and rehydrate tags as set

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -307,7 +307,7 @@ export class Ext extends Ecs.System<ExtEvent> {
             auto_tiler: this.auto_tiler,
             entities: this.entities_,
             storages: this.storages,
-            tags: this.tags_,
+            tags: this.tags_.map(set => [...set]),
             free_slots: this.free_slots,
             displays: [
                 this.displays[0],
@@ -382,7 +382,8 @@ export class Ext extends Ecs.System<ExtEvent> {
                 )
             );
             ext.tags_ = data.tags.map(
-                (obj: any) => new Set(Object.entries(obj))
+                (val: any) =>
+                    new Set(Array.isArray(val) ? val : Object.entries(val))
             );
             ext.free_slots = data.free_slots;
             if (data.displays) {

--- a/src/forest.ts
+++ b/src/forest.ts
@@ -89,7 +89,7 @@ export class Forest extends Ecs.World {
             string_reps: this.string_reps,
             entities: this.entities_,
             storages: this.storages,
-            tags: this.tags_,
+            tags: this.tags_.map(set => [...set]),
             free_slots: this.free_slots,
         };
     }
@@ -114,7 +114,8 @@ export class Forest extends Ecs.World {
             Ecs.Storage.fromJSON(obj.store, val => val)
         );
         forest.tags_ = data.tags.map(
-            (obj: any) => new Set(Object.entries(obj))
+            (val: any) =>
+                new Set(Array.isArray(val) ? val : Object.entries(val))
         );
         forest.free_slots = data.free_slots;
         return forest;


### PR DESCRIPTION
## 📝 Description

sets are not json serializable and therefore the tags were getting clobbered during rehydration. this addresses the issue by converting the set to an array on cache and converts it back to a set on rehydration.

---

## 🔍 Type of Change

Please delete options that are not relevant.

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code cleanup or refactor
- [ ] 🧪 Tests
- [ ] 📝 Documentation update
- [ ] ⚙️ CI/CD or build system update

closes #151 
