### PR TITLE
fix(ext):[#210] set indicator visibility on enable

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3178,6 +3178,7 @@ export default class MosaicExtension extends Extension {
             if (!indicator) {
                 indicator = new PanelSettings.MosaicIndicator(ext);
             }
+            ext.toggle_indicator();
 
             ext.keybindings
                 .enable(ext, ext.keybindings.global)


### PR DESCRIPTION
## 📝 Description

on enable, the indicator is created, but its visibility is not set based on the settings.  this makes the indicator come back after unlock

---

## 🔍 Type of Change

Please delete options that are not relevant.

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code cleanup or refactor
- [ ] 🧪 Tests
- [ ] 📝 Documentation update
- [ ] ⚙️ CI/CD or build system update

closes #210