### PR TITLE
fix: gnome overview stutter

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2248,11 +2248,14 @@ export class Ext extends Ecs.System<ExtEvent> {
         });
 
         this.connect(overview, 'hiding', () => {
+            this.register(Events.global(GlobalEvent.OverviewHidden));
+        });
+
+        this.connect(overview, 'hidden', () => {
             const window = this.focus_window();
             if (window) {
                 this.on_focused(window);
             }
-            this.register(Events.global(GlobalEvent.OverviewHidden));
         });
 
         // We have to connect this signal in an idle_add; otherwise work areas stop being calculated

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -983,36 +983,38 @@ export class Ext extends Ecs.System<ExtEvent> {
             this.prev_focused[1] = win.entity;
         }
 
-        this.unmaximize_workspace(win);
+        if (!Main.overview.animationInProgress) {
+            this.unmaximize_workspace(win);
 
-        this.show_border_on_focused();
-        this.set_overlay(win);
-
-        if (
-            this.auto_tiler &&
-            win.is_tilable(this) &&
-            this.prev_focused[0] !== null
-        ) {
-            let prev = this.windows.get(this.prev_focused[0]);
-            let is_attached = this.auto_tiler.attached.contains(
-                this.prev_focused[0]
-            );
+            this.show_border_on_focused();
+            this.set_overlay(win);
 
             if (
-                prev &&
-                prev !== win &&
-                is_attached &&
-                prev.actor_exists() &&
-                prev.name(this) !== win.name(this) &&
-                prev.workspace_id() === win.workspace_id()
+                this.auto_tiler &&
+                win.is_tilable(this) &&
+                this.prev_focused[0] !== null
             ) {
-                if (prev.rect().contains(win.rect())) {
-                    if (prev.is_maximized()) {
-                        prev.meta.set_unmaximize_flags
-                            ? prev.meta.set_unmaximize_flags(
-                                  Meta.MaximizeFlags.BOTH
-                              )
-                            : prev.meta.unmaximize(Meta.MaximizeFlags.BOTH);
+                let prev = this.windows.get(this.prev_focused[0]);
+                let is_attached = this.auto_tiler.attached.contains(
+                    this.prev_focused[0]
+                );
+
+                if (
+                    prev &&
+                    prev !== win &&
+                    is_attached &&
+                    prev.actor_exists() &&
+                    prev.name(this) !== win.name(this) &&
+                    prev.workspace_id() === win.workspace_id()
+                ) {
+                    if (prev.rect().contains(win.rect())) {
+                        if (prev.is_maximized()) {
+                            prev.meta.set_unmaximize_flags
+                                ? prev.meta.set_unmaximize_flags(
+                                      Meta.MaximizeFlags.BOTH
+                                  )
+                                : prev.meta.unmaximize(Meta.MaximizeFlags.BOTH);
+                        }
                     }
                 }
             }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2128,6 +2128,9 @@ export class Ext extends Ecs.System<ExtEvent> {
         this.overlay.width = win.rect().width;
         this.overlay.height = win.rect().height;
 
+        // Skip radii capture for better performance
+        if (!this.overlay.visible) return;
+
         const radii = await getBorderRadii(
             win.meta.get_compositor_private() as Meta.WindowActor
         );

--- a/src/tiling.ts
+++ b/src/tiling.ts
@@ -752,8 +752,8 @@ export class Tiler {
             }
 
             // Set overlay to match window
-            this.ext.set_overlay(win);
             this.ext.overlay.visible = true;
+            this.ext.set_overlay(win);
 
             if (
                 !this.ext.auto_tiler ||

--- a/src/window.ts
+++ b/src/window.ts
@@ -767,9 +767,27 @@ function pointer_already_on_window(meta: Meta.Window): boolean {
     return cursor.intersects(meta.get_frame_rect());
 }
 
+type Radii = [number, number, number, number];
+
+interface RadiiCacheEntry {
+    signature: string;
+    radii: Radii;
+}
+
+const border_radii_cache = new WeakMap<Meta.WindowActor, RadiiCacheEntry>();
+
+function radii_signature(meta: Meta.Window, scale: number): string {
+    return [
+        meta.get_wm_class(),
+        meta.is_fullscreen(),
+        meta.is_maximized(),
+        scale,
+    ].join(':');
+}
+
 export async function getBorderRadii(
     actor: Meta.WindowActor
-): Promise<[number, number, number, number] | undefined> {
+): Promise<Radii | undefined> {
     const opaqueLimit = 200;
     const {x, y, width, height} = actor.get_meta_window().get_frame_rect();
     const monitorIndex = actor.get_meta_window().get_monitor();
@@ -777,6 +795,16 @@ export async function getBorderRadii(
     const scale = Math.ceil(global.display.get_monitor_scale(monitorIndex));
 
     if (height <= 0) return;
+
+    const meta = actor.get_meta_window();
+    const signature = radii_signature(meta, scale);
+
+    // Radii depend only on the window decoration, so cache them to avoid a
+    // full-window paint_to_content readback on every focus change.
+    const cached = border_radii_cache.get(actor);
+    if (cached && cached.signature === signature) {
+        return cached.radii;
+    }
 
     const capture = (actor as any).paint_to_content(
         new Mtk.Rectangle({x, y, width, height})
@@ -833,5 +861,7 @@ export async function getBorderRadii(
     const radiusTop = alphaTop / scale;
     const radiusBottom = alphaBottom / scale;
 
-    return [radiusTop, radiusTop, radiusBottom, radiusBottom];
+    const radii: Radii = [radiusTop, radiusTop, radiusBottom, radiusBottom];
+    border_radii_cache.set(actor, {signature, radii});
+    return radii;
 }


### PR DESCRIPTION
## 📝 Description

this introduces several fixes intended to increase performance and fix the overview hiding animation stutter.  the main things here are:

- deferring the on_focused event until after the hiding animation is completed
- guarding and returning early around components that use the radii compute func
- caching radii values when appropriate to avoid writing surfaces to a buffer

---

## 🔍 Type of Change

Please delete options that are not relevant.

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code cleanup or refactor
- [ ] 🧪 Tests
- [ ] 📝 Documentation update
- [ ] ⚙️ CI/CD or build system update

---

closes #175 