### PR TITLE
fix(overlay): use set_overlay on window events

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1730,12 +1730,8 @@ export class Ext extends Ecs.System<ExtEvent> {
                             : auto_tiler.cursor_placement(area, cursor);
 
                         if (!result) {
-                            this.overlay.x = area.x;
-                            this.overlay.y = area.y;
-                            this.overlay.width = area.width;
-                            this.overlay.height = area.height;
-
                             this.overlay.visible = true;
+                            this.set_overlay(attach_to ?? win, area);
 
                             return true;
                         }
@@ -1773,11 +1769,11 @@ export class Ext extends Ecs.System<ExtEvent> {
                             );
                         }
 
-                        this.overlay.x = new_area[0];
-                        this.overlay.y = new_area[1];
-                        this.overlay.width = new_area[2];
-                        this.overlay.height = new_area[3];
                         this.overlay.visible = true;
+                        this.set_overlay(
+                            attach_to ?? win,
+                            new Rect.Rectangle(new_area)
+                        );
 
                         return true;
                     }
@@ -2122,11 +2118,13 @@ export class Ext extends Ecs.System<ExtEvent> {
         this.gap_outer = gap * 4 * this.dpi;
     }
 
-    async set_overlay(win: Window.ShellWindow) {
-        this.overlay.x = win.rect().x;
-        this.overlay.y = win.rect().y;
-        this.overlay.width = win.rect().width;
-        this.overlay.height = win.rect().height;
+    async set_overlay(win: Window.ShellWindow, area?: Rectangular) {
+        const rect = area ?? win.rect();
+
+        this.overlay.x = rect.x;
+        this.overlay.y = rect.y;
+        this.overlay.width = rect.width;
+        this.overlay.height = rect.height;
 
         // Skip radii capture for better performance
         if (!this.overlay.visible) return;


### PR DESCRIPTION
## 📝 Description

- add optional param to set_overlay to handle generic rect for usage with movement previews
- utilize set_overlay for styling on window events
- reorder overlay visibility to happen directly before styling so that the guard is not blocking
---

## 🔍 Type of Change

Please delete options that are not relevant.

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code cleanup or refactor
- [ ] 🧪 Tests
- [ ] 📝 Documentation update
- [ ] ⚙️ CI/CD or build system update

