### PR TITLE
docs: add Super+Y toggle-tiling shortcut to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Disabled by default, this mode manages windows using a tree-based tiling window 
 | ------------- | ------------------------------------------------------ |
 | `Super` + `O` | Toggles the orientation of a fork's tiling orientation |
 | `Super` + `G` | Toggles a window between floating and tiling.          |
+| `Super` + `Y` | Toggles auto-tiling on and off.                        |
 | `Super` + `R` | Enter window resizing mode                             |
 
 ### Customizing the Floating Window List


### PR DESCRIPTION
The `toggle-tiling` keybinding (`Super+Y`) was configured in the
gschema but missing from the Tiling Mode keyboard shortcuts table
in the README. This adds it alongside the existing
`Super+O` and `Super+G` entries.