### PR TITLE
docs: explain shortcut-only configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ GNU Make and TypeScript are also required to build the project.
 
 Proper functionality of the shell requires modifying GNOME's default keyboard shortcuts. For a local installation, run `make local-install`.
 
+Installing Mosaic from extensions.gnome.org does not modify those shortcuts. To apply Mosaic's shortcut configuration without reinstalling the extension, clone this repository and run `make configure` from the repository directory as your normal user.
+
 If you want to uninstall the extension, you may invoke `make uninstall`, and then open the "Keyboard Shortcuts" panel in GNOME Settings to select the "Reset All.." button in the header bar.
 
 > [!Important]


### PR DESCRIPTION
## Summary

- explain that the extensions.gnome.org installation does not modify GNOME shortcuts
- document `make configure` for applying Mosaic shortcuts without reinstalling the extension

## Context

This is a workaround for #216. It documents the existing manual configuration path; it does not make shortcuts apply automatically when Mosaic is installed from extensions.gnome.org.

## Validation

- `git diff --check`