### PR TITLE
fix: add exceptions for wl-clipboard

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -60,6 +60,7 @@ export const DEFAULT_FLOAT_RULES: Array<FloatRule> = [
     {class: 'zoom'},
     {class: '^.*action=join.*$'},
     {class: 'gjs'},
+    {class: 'io.github.bugaevc.wl-clipboard'},
 ];
 
 export interface WindowRule {
@@ -78,6 +79,7 @@ export const SKIPTASKBAR_EXCEPTIONS: Array<WindowRule> = [
     {class: 'Guake'},
     {class: 'Com.github.amezin.ddterm'},
     {class: 'plank'},
+    {class: 'io.github.bugaevc.wl-clipboard'},
 ];
 
 export interface FloatRule {


### PR DESCRIPTION
wl-clipboard invisible window (literally just a dot shows up) can cause the tiler to make it take an entire window worth of space, and it is supposed to be immediately closed so we see a tiling flicker. And also sometimes the window dangles (there is an open bug for it), so it takes up unnecessary space.

This window is not supposed to be tiled, in fact it has skip-taskbar flag set. Let's add exceptions for it.

Relates: https://github.com/pop-os/shell/issues/1819
Closes: #219