### PR TITLE
fix:[#220] prevent DING desktop from stealing focus

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -61,6 +61,7 @@ export const DEFAULT_FLOAT_RULES: Array<FloatRule> = [
     {class: '^.*action=join.*$'},
     {class: 'gjs'},
     {class: 'io.github.bugaevc.wl-clipboard'},
+    {class: 'com.rastersoft.ding'},
 ];
 
 export interface WindowRule {
@@ -80,6 +81,7 @@ export const SKIPTASKBAR_EXCEPTIONS: Array<WindowRule> = [
     {class: 'Com.github.amezin.ddterm'},
     {class: 'plank'},
     {class: 'io.github.bugaevc.wl-clipboard'},
+    {class: 'com.rastersoft.ding'},
 ];
 
 export interface FloatRule {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,7 +25,7 @@ import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
 import type {Entity} from './ecs.js';
 import type {ExtEvent} from './events.js';
 import {Rectangle} from './rectangle.js';
-import {getBorderRadii} from './window.js';
+import {getBorderRadii, is_desktop_window} from './window.js';
 
 import {Fork} from './fork.js';
 
@@ -2328,6 +2328,16 @@ export class Ext extends Ecs.System<ExtEvent> {
                     let meta_window = global.display.get_focus_window();
 
                     if (meta_window) {
+                        // Desktop icon extensions initially map their desktop surface as a
+                        // normal window and only mark it as a desktop afterwards. It may
+                        // therefore already have a ShellWindow entry by the time it receives
+                        // focus, so check for desktop surfaces before consulting our window
+                        // table.
+                        if (this.auto_tiler && is_desktop_window(meta_window)) {
+                            refocus_tiled_window();
+                            return;
+                        }
+
                         const shell_window = this.get_window(meta_window);
 
                         if (shell_window) {
@@ -2339,17 +2349,8 @@ export class Ext extends Ecs.System<ExtEvent> {
                                 this.on_focused(shell_window);
                             }
                         } else if (!meta_window.is_override_redirect()) {
-                            // Prevent focusing desktop extension in auto-tiler mode
-                            if (
-                                this.auto_tiler &&
-                                meta_window.window_type ===
-                                    Meta.WindowType.DESKTOP
-                            ) {
-                                refocus_tiled_window();
-                            } else {
-                                // This section fixes Steam's sub-menus.
-                                meta_window.activate(global.get_current_time());
-                            }
+                            // This section fixes Steam's sub-menus.
+                            meta_window.activate(global.get_current_time());
                         }
                     } else if (this.auto_tiler) {
                         refocus_tiled_window();
@@ -3091,6 +3092,8 @@ export class Ext extends Ecs.System<ExtEvent> {
     /// Fetches the window entity which is associated with the metacity window metadata.
     window_entity(meta: Meta.Window | null): Entity | null {
         if (!meta) return null;
+
+        if (is_desktop_window(meta)) return null;
 
         let id: number;
 

--- a/src/window.ts
+++ b/src/window.ts
@@ -915,3 +915,16 @@ export async function getBorderRadii(
         memoryBuffer.close(null);
     }
 }
+
+/** Detect desktop surfaces, including DING's Wayland desktop emulation. */
+export function is_desktop_window(meta_win: Meta.Window): boolean {
+    const is_ding_desktop =
+        !meta_win.decorated &&
+        (meta_win as any).get_gtk_application_id?.() === 'com.rastersoft.ding';
+
+    return (
+        meta_win.window_type === Meta.WindowType.DESKTOP ||
+        (meta_win as any).customJS_ding?.keepAtBottom === true ||
+        is_ding_desktop
+    );
+}


### PR DESCRIPTION
## 📝 Description
- add DING to sys exceptions list
- prevent DING desktop from stealing focus

---

## 🔍 Type of Change

Please delete options that are not relevant.

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code cleanup or refactor
- [ ] 🧪 Tests
- [ ] 📝 Documentation update
- [ ] ⚙️ CI/CD or build system update

adapted from: https://github.com/pop-os/shell/pull/1824
closes #220