### PR TITLE
feat: add gnome 51 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ $(info UUID is "$(UUID)")
 
 sources = src/*.ts *.css
 
-all: depcheck compile
+all: depcheck compile translations
 
 clean:
 	rm -rf _build target

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   </a>
 </div>
 <div align="right">
-  <img src="https://img.shields.io/badge/GNOME-45--50-e66100?style=for-the-badge&logo=gnome&logoColor=white"/>
+  <img src="https://img.shields.io/badge/GNOME-45--51-e66100?style=for-the-badge&logo=gnome&logoColor=white"/>
   <img src="https://img.shields.io/github/license/jardon/gnome-mosaic?style=for-the-badge&color=2ec27e"/>
 </div>
 

--- a/metadata.json
+++ b/metadata.json
@@ -6,6 +6,6 @@
     "uuid": "gnome-mosaic@jardon.github.com",
     "url": "https://github.com/jardon/gnome-mosaic",
     "settings-schema": "org.gnome.shell.extensions.gnome-mosaic",
-    "shell-version": ["45", "46", "47", "48", "49", "50"],
+    "shell-version": ["45", "46", "47", "48", "49", "50", "51"],
     "gettext-domain": "gnome-mosaic@jardon.github.com"
 }

--- a/scripts/transpile.sh
+++ b/scripts/transpile.sh
@@ -14,8 +14,6 @@ transpile() {
     #     | sed -E "s/import \* as (\w+) from '(\w+)'/const \1 = Me.imports.\2/g" > "${dest}"
 }
 
-rm -rf _build
-
 glib-compile-schemas schemas &
 
 # Transpile to JavaScript

--- a/src/tiling.ts
+++ b/src/tiling.ts
@@ -17,6 +17,7 @@ import Clutter from 'gi://Clutter';
 import Meta from 'gi://Meta';
 import St from 'gi://St';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import * as Config from 'resource:///org/gnome/shell/misc/config.js';
 const {layoutManager} = Main;
 const {ShellWindow} = window;
 
@@ -38,9 +39,18 @@ export class Tiler {
     private resize_keymon: null | number = null;
     private resize_keymon_release: null | number = null;
 
-    private resize_hint: St.Widget = new St.BoxLayout({
-        vertical: true,
-    });
+    private major = Config.PACKAGE_VERSION.split('.').map((s: string) =>
+        Number(s)
+    )[0];
+
+    // MIN GNOME VERSION 48
+    // https://gjs.guide/extensions/upgrading/gnome-shell-48.html
+    private st_vertical_config =
+        this.major >= 48
+            ? {orientation: Clutter.Orientation.VERTICAL}
+            : {vertical: true};
+
+    private resize_hint: St.Widget = new St.BoxLayout(this.st_vertical_config);
 
     private resize_up: St.Icon = new St.Icon({
         icon_name: ICON_UP_ARROW,
@@ -121,7 +131,7 @@ export class Tiler {
         right_box.add_child(this.resize_right);
 
         const middle_arrows: St.Widget = new St.BoxLayout({
-            vertical: false,
+            ...this.st_vertical_config,
             x_expand: true,
             y_expand: true,
         });


### PR DESCRIPTION
## 📝 Description

- dynamically load st.boxlayout properties based on gnome version
- add gnome 51 to metadata
- fix make zip-file

---

## 🔍 Type of Change

Please delete options that are not relevant.

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code cleanup or refactor
- [ ] 🧪 Tests
- [ ] 📝 Documentation update
- [ ] ⚙️ CI/CD or build system update

