### PR TITLE
fix(active-hint) use get_maximized pre 49 with border funcs

### DIFF
--- a/src/window.ts
+++ b/src/window.ts
@@ -643,6 +643,8 @@ export class ShellWindow {
                     }
                 }
             } while (this.border_style_queued);
+        } catch (error) {
+            log.error(`cannot update border style: ${error}`);
         } finally {
             this.border_style_in_progress = false;
         }

--- a/src/window.ts
+++ b/src/window.ts
@@ -298,9 +298,7 @@ export class ShellWindow {
     }
 
     is_maximized(): boolean {
-        return this.meta.is_maximized
-            ? this.meta.is_maximized()
-            : this.meta.get_maximized() !== 0;
+        return is_maximized(this.meta);
     }
 
     /**
@@ -805,7 +803,7 @@ function radii_signature(meta: Meta.Window, scale: number): string {
     return [
         meta.get_wm_class(),
         meta.is_fullscreen(),
-        meta.is_maximized(),
+        is_maximized(meta),
         scale,
     ].join(':');
 }
@@ -817,7 +815,7 @@ export async function getBorderRadii(
     const meta = actor.get_meta_window();
     if (!meta) return;
 
-    if (meta.is_fullscreen() || meta.is_maximized()) return;
+    if (meta.is_fullscreen() || is_maximized(meta)) return;
 
     const opaqueLimit = 200;
     const {x, y, width, height} = meta.get_frame_rect();
@@ -929,4 +927,9 @@ export function is_desktop_window(meta_win: Meta.Window): boolean {
         (meta_win as any).customJS_ding?.keepAtBottom === true ||
         is_ding_desktop
     );
+}
+
+function is_maximized(meta: Meta.Window): boolean {
+    // MIN GNOME 49
+    return meta.is_maximized ? meta.is_maximized() : meta.get_maximized() !== 0;
 }


### PR DESCRIPTION
## 📝 Description

- add catch to border style update
- fix get_maximized removal workaround for border funcs

---

## 🔍 Type of Change

Please delete options that are not relevant.

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code cleanup or refactor
- [ ] 🧪 Tests
- [ ] 📝 Documentation update
- [ ] ⚙️ CI/CD or build system update
