### PR TITLE
fix(ext):[#237] remove early return on win destroy

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -942,24 +942,24 @@ export class Ext extends Ecs.System<ExtEvent> {
         }
 
         const window = this.windows.get(win);
-        if (!window) return;
+        if (window) {
+            window.destroying = true;
 
-        window.destroying = true;
+            this.size_requests.delete(window.meta);
+
+            // Disconnect all signals on this window
+            this.window_signals.take_with(win, signals => {
+                for (const signal of signals) {
+                    window.meta.disconnect(signal);
+                }
+            });
+        }
 
         const deferred = this.deferred_tiles.get(win);
         if (deferred) {
             GLib.source_remove(deferred.id);
             this.deferred_tiles.delete(win);
         }
-
-        this.size_requests.delete(window.meta);
-
-        // Disconnect all signals on this window
-        this.window_signals.take_with(win, signals => {
-            for (const signal of signals) {
-                window.meta.disconnect(signal);
-            }
-        });
 
         if (this.auto_tiler) {
             const entity = this.auto_tiler.attached.get(win);

--- a/src/window.ts
+++ b/src/window.ts
@@ -930,6 +930,7 @@ export function is_desktop_window(meta_win: Meta.Window): boolean {
 }
 
 function is_maximized(meta: Meta.Window): boolean {
-    // MIN GNOME 49
+    // MIN GNOME 49 VERSION
+    // https://gjs.guide/extensions/upgrading/gnome-shell-49.html
     return meta.is_maximized ? meta.is_maximized() : meta.get_maximized() !== 0;
 }


### PR DESCRIPTION
## 📝 Description

as requested in [EGO review](https://extensions.gnome.org/review/74955), remove the early return on window destroy 

---

## 🔍 Type of Change

Please delete options that are not relevant.

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code cleanup or refactor
- [ ] 🧪 Tests
- [ ] 📝 Documentation update
- [ ] ⚙️ CI/CD or build system update

closes #237 